### PR TITLE
Make favorites appear first

### DIFF
--- a/src/frontend/menu-loader.c
+++ b/src/frontend/menu-loader.c
@@ -143,8 +143,8 @@ void brisk_menu_window_remove_category(GtkWidget *widget, BriskMenuWindow *self)
  */
 void brisk_menu_window_init_backends(BriskMenuWindow *self)
 {
-        brisk_menu_window_insert_backend(self, brisk_all_items_backend_new());
         brisk_menu_window_insert_backend(self, brisk_favourites_backend_new());
+        brisk_menu_window_insert_backend(self, brisk_all_items_backend_new());
         brisk_menu_window_insert_backend(self, brisk_apps_backend_new());
 }
 


### PR DESCRIPTION
Solves https://github.com/solus-project/brisk-menu/issues/100

I believe this is best as the default option, but it should be improved with an empty state telling the user they don't have any favorites, encouraging them to add some.