### PR TITLE
Fix for categories list always showing a scrollbar

### DIFF
--- a/src/frontend/classic/sidebar-scroller.c
+++ b/src/frontend/classic/sidebar-scroller.c
@@ -76,6 +76,8 @@ static void brisk_menu_sidebar_scroller_get_preferred_height(GtkWidget *widget, 
 {
         GdkScreen *screen = NULL;
         GdkWindow *window = NULL;
+        GtkStyleContext *style_context = NULL;
+        GtkBorder border;
         GdkRectangle geom = { 0 };
         gint applet_x, applet_y = 0;
         gint mon = 0;
@@ -97,10 +99,13 @@ static void brisk_menu_sidebar_scroller_get_preferred_height(GtkWidget *widget, 
         bin = GTK_BIN(widget);
         child = gtk_bin_get_child(bin);
 
+        style_context = gtk_widget_get_style_context(widget);
+        gtk_style_context_get_border(style_context, GTK_STATE_FLAG_NORMAL, &border);
+
         if (child) {
                 gtk_widget_get_preferred_height(child, min_height, nat_height);
-                *min_height = MIN(max_height, *min_height);
-                *nat_height = MIN(max_height, *nat_height);
+                *min_height = MIN(max_height, *min_height) + border.top + border.bottom;
+                *nat_height = MIN(max_height, *nat_height) + border.top + border.bottom;
         } else {
                 *min_height = *nat_height = 0;
         }

--- a/src/frontend/classic/sidebar-scroller.c
+++ b/src/frontend/classic/sidebar-scroller.c
@@ -77,7 +77,11 @@ static void brisk_menu_sidebar_scroller_get_preferred_height(GtkWidget *widget, 
         GdkScreen *screen = NULL;
         GdkWindow *window = NULL;
         GtkStyleContext *style_context = NULL;
+        GtkStateFlags state_flags;
         GtkBorder border;
+        GtkBorder padding;
+        GtkBorder margin;
+        gint spacing;
         GdkRectangle geom = { 0 };
         gint applet_x, applet_y = 0;
         gint mon = 0;
@@ -100,12 +104,17 @@ static void brisk_menu_sidebar_scroller_get_preferred_height(GtkWidget *widget, 
         child = gtk_bin_get_child(bin);
 
         style_context = gtk_widget_get_style_context(widget);
-        gtk_style_context_get_border(style_context, GTK_STATE_FLAG_NORMAL, &border);
+        state_flags = gtk_widget_get_state_flags(widget);
+        gtk_style_context_get_border(style_context, state_flags, &border);
+        gtk_style_context_get_padding(style_context, state_flags, &padding);
+        gtk_style_context_get_margin(style_context, state_flags, &margin);
+
+        spacing = border.top + border.bottom + padding.top + padding.bottom + margin.top + margin.bottom;
 
         if (child) {
                 gtk_widget_get_preferred_height(child, min_height, nat_height);
-                *min_height = MIN(max_height, *min_height) + border.top + border.bottom;
-                *nat_height = MIN(max_height, *nat_height) + border.top + border.bottom;
+                *min_height = MIN(max_height, *min_height) + spacing;
+                *nat_height = MIN(max_height, *nat_height) + spacing;
         } else {
                 *min_height = *nat_height = 0;
         }


### PR DESCRIPTION
This is a fix for an issue from the old repo: solus-project/brisk-menu#83

The problem is that `gtk_widget_get_preferred_height` expects the height to include the border width as well. Therefore, on themes* that have a border around `BriskMenuSidebarScroller`, the scroller will always be a few pixels shorter.

(*) https://github.com/ubuntu-mate/ubuntu-mate-artwork/blob/master/usr/share/themes/Ambiant-MATE/gtk-3.0/apps/mate-applications.css#L694