### PR TITLE
backend: Hide menu when rebuilding menu items

### DIFF
--- a/src/backend/apps/apps-backend.c
+++ b/src/backend/apps/apps-backend.c
@@ -296,9 +296,13 @@ static gboolean brisk_apps_backend_reload(BriskAppsBackend *self)
                 return G_SOURCE_REMOVE;
         }
 
-        /* First things first, reset everything we own */
+        /* First things first, hide the menu to avoid reseting on a live list */
+        brisk_backend_hide_menu(BRISK_BACKEND(self));
+
+        /* Then, reset everything we own */
         brisk_backend_reset(BRISK_BACKEND(self));
 
+        /* Now we can recreate the menu items */
         brisk_apps_backend_init_menus(self);
 
         /* Reset ourselves for the next time */


### PR DESCRIPTION
Since we have a monitor to update the menu whenever the desktop files
are updated, the list of filtered menu items can change while the user
is actively navigating through it. This causes the GtkListBox filters to
segfault.

Hiding the menu whenever the GAppInfoMonitor fires the "changed" signal
clears out the GtkListBox, and so no filtering is happening. This only
happens when installing or removing applications while browsing the
menu, so it should not be generally disruptive, and will prevent the
menu from crashing.