### PR TITLE
frontend: Allow keyboard navigation

### DIFF
--- a/src/frontend/classic/category-button.c
+++ b/src/frontend/classic/category-button.c
@@ -180,12 +180,9 @@ static void brisk_classic_category_button_init(BriskClassicCategoryButton *self)
                      NULL);
         gtk_box_pack_start(GTK_BOX(layout), label, TRUE, TRUE, 0);
 
-        /* Button specific fixes */
-        gtk_widget_set_can_focus(GTK_WIDGET(self), FALSE);
-
         /* Look like a button */
         g_object_set(G_OBJECT(self), "draw-indicator", FALSE, NULL);
-        gtk_widget_set_can_focus(GTK_WIDGET(self), FALSE);
+        gtk_widget_set_can_focus(GTK_WIDGET(self), TRUE);
 
         /* Flatten the button */
         style = gtk_widget_get_style_context(GTK_WIDGET(self));

--- a/src/frontend/classic/classic-window.c
+++ b/src/frontend/classic/classic-window.c
@@ -30,7 +30,7 @@ G_DEFINE_TYPE(BriskClassicWindow, brisk_classic_window, BRISK_TYPE_MENU_WINDOW)
 
 static void brisk_classic_window_associate_category(BriskMenuWindow *self, GtkWidget *button);
 static void brisk_classic_window_on_toggled(BriskMenuWindow *self, GtkWidget *button);
-static gboolean brisk_classic_window_on_enter(BriskMenuWindow *self, GdkEventCrossing *event,
+static gboolean brisk_classic_window_on_enter(BriskMenuWindow *self, GdkEvent *event,
                                               GtkWidget *button);
 static void brisk_classic_window_load_css(BriskClassicWindow *self);
 static void brisk_classic_window_key_activate(BriskClassicWindow *self, gpointer v);
@@ -244,6 +244,8 @@ static void brisk_classic_window_invalidate_filter(BriskMenuWindow *self,
 {
         gtk_list_box_invalidate_filter(GTK_LIST_BOX(BRISK_CLASSIC_WINDOW(self)->apps));
         gtk_list_box_invalidate_sort(GTK_LIST_BOX(BRISK_CLASSIC_WINDOW(self)->apps));
+
+        gtk_list_box_unselect_all(GTK_LIST_BOX(BRISK_CLASSIC_WINDOW(self)->apps));
 }
 
 /**
@@ -519,6 +521,10 @@ static void brisk_classic_window_associate_category(BriskMenuWindow *self, GtkWi
                                  "enter-notify-event",
                                  G_CALLBACK(brisk_classic_window_on_enter),
                                  self);
+        g_signal_connect_swapped(button,
+                                 "focus-in-event",
+                                 G_CALLBACK(brisk_classic_window_on_enter),
+                                 self);
 }
 
 /**
@@ -541,11 +547,10 @@ static void brisk_classic_window_on_toggled(BriskMenuWindow *self, GtkWidget *bu
 }
 
 /**
- * Fired by entering into the category button with a roll over
+ * Fired by entering into the category button
  */
 static gboolean brisk_classic_window_on_enter(BriskMenuWindow *self,
-                                              __brisk_unused__ GdkEventCrossing *event,
-                                              GtkWidget *button)
+                                              __brisk_unused__ GdkEvent *event, GtkWidget *button)
 {
         GtkToggleButton *but = GTK_TOGGLE_BUTTON(button);
 
@@ -558,7 +563,8 @@ static gboolean brisk_classic_window_on_enter(BriskMenuWindow *self,
                 return GDK_EVENT_PROPAGATE;
         }
 
-        /* Force activation through rollover */
+        /* Force activation */
+        gtk_widget_grab_focus(button);
         gtk_toggle_button_set_active(but, TRUE);
 
         return GDK_EVENT_PROPAGATE;
@@ -657,7 +663,7 @@ static void brisk_classic_window_setup_session_controls(BriskClassicWindow *self
         self->button_logout = widget;
         g_signal_connect_swapped(widget, "clicked", G_CALLBACK(brisk_menu_window_logout), self);
         gtk_widget_set_tooltip_text(widget, _("End the current session"));
-        gtk_widget_set_can_focus(widget, FALSE);
+        gtk_widget_set_can_focus(widget, TRUE);
         gtk_container_add(GTK_CONTAINER(box), widget);
         style = gtk_widget_get_style_context(widget);
         gtk_style_context_add_class(style, GTK_STYLE_CLASS_FLAT);
@@ -669,7 +675,7 @@ static void brisk_classic_window_setup_session_controls(BriskClassicWindow *self
         self->button_lock = widget;
         g_signal_connect_swapped(widget, "clicked", G_CALLBACK(brisk_menu_window_lock), self);
         gtk_widget_set_tooltip_text(widget, _("Lock the screen"));
-        gtk_widget_set_can_focus(widget, FALSE);
+        gtk_widget_set_can_focus(widget, TRUE);
         gtk_container_add(GTK_CONTAINER(box), widget);
         style = gtk_widget_get_style_context(widget);
         gtk_style_context_add_class(style, GTK_STYLE_CLASS_FLAT);
@@ -681,7 +687,7 @@ static void brisk_classic_window_setup_session_controls(BriskClassicWindow *self
         self->button_shutdown = widget;
         g_signal_connect_swapped(widget, "clicked", G_CALLBACK(brisk_menu_window_shutdown), self);
         gtk_widget_set_tooltip_text(widget, _("Turn off the device"));
-        gtk_widget_set_can_focus(widget, FALSE);
+        gtk_widget_set_can_focus(widget, TRUE);
         gtk_container_add(GTK_CONTAINER(box), widget);
         style = gtk_widget_get_style_context(widget);
         gtk_style_context_add_class(style, GTK_STYLE_CLASS_FLAT);

--- a/src/frontend/classic/desktop-button.c
+++ b/src/frontend/classic/desktop-button.c
@@ -192,7 +192,7 @@ static void brisk_menu_desktop_button_init(BriskMenuDesktopButton *self)
         gtk_box_pack_start(GTK_BOX(layout), label, TRUE, TRUE, 0);
 
         /* Button specific fixes */
-        gtk_widget_set_can_focus(GTK_WIDGET(self), FALSE);
+        gtk_widget_set_can_focus(GTK_WIDGET(self), TRUE);
         gtk_button_set_relief(GTK_BUTTON(self), GTK_RELIEF_NONE);
 
         /* Flatten the button */

--- a/src/frontend/dash/category-button.c
+++ b/src/frontend/dash/category-button.c
@@ -157,12 +157,9 @@ static void brisk_dash_category_button_init(BriskDashCategoryButton *self)
         g_object_set(self->label, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
         gtk_box_pack_start(GTK_BOX(layout), label, TRUE, TRUE, 0);
 
-        /* Button specific fixes */
-        gtk_widget_set_can_focus(GTK_WIDGET(self), FALSE);
-
         /* Look like a button */
         g_object_set(G_OBJECT(self), "draw-indicator", FALSE, NULL);
-        gtk_widget_set_can_focus(GTK_WIDGET(self), FALSE);
+        gtk_widget_set_can_focus(GTK_WIDGET(self), TRUE);
 
         /* Flatten the button */
         style = gtk_widget_get_style_context(GTK_WIDGET(self));

--- a/src/frontend/dash/dash-window.c
+++ b/src/frontend/dash/dash-window.c
@@ -25,7 +25,7 @@ G_DEFINE_TYPE(BriskDashWindow, brisk_dash_window, BRISK_TYPE_MENU_WINDOW)
 
 static void brisk_dash_window_associate_category(BriskMenuWindow *self, GtkWidget *button);
 static void brisk_dash_window_on_toggled(BriskMenuWindow *self, GtkWidget *button);
-static gboolean brisk_dash_window_on_enter(BriskMenuWindow *self, GdkEventCrossing *event,
+static gboolean brisk_dash_window_on_enter(BriskMenuWindow *self, GdkEvent *event,
                                            GtkWidget *button);
 static void brisk_dash_window_load_css(GtkSettings *settings, const gchar *key,
                                        BriskDashWindow *self);
@@ -194,6 +194,8 @@ static void brisk_dash_window_invalidate_filter(BriskMenuWindow *self,
 {
         gtk_flow_box_invalidate_filter(GTK_FLOW_BOX(BRISK_DASH_WINDOW(self)->apps));
         gtk_flow_box_invalidate_sort(GTK_FLOW_BOX(BRISK_DASH_WINDOW(self)->apps));
+
+        gtk_flow_box_unselect_all(GTK_FLOW_BOX(BRISK_DASH_WINDOW(self)->apps));
 }
 
 /**
@@ -379,7 +381,7 @@ static void brisk_dash_window_init(BriskDashWindow *self)
         gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll),
                                        GTK_POLICY_AUTOMATIC,
                                        GTK_POLICY_NEVER);
-        gtk_widget_set_can_focus(scroll, FALSE);
+        gtk_widget_set_can_focus(scroll, TRUE);
         gtk_scrolled_window_set_overlay_scrolling(GTK_SCROLLED_WINDOW(scroll), TRUE);
         self->categories_scroll = scroll;
 
@@ -484,6 +486,10 @@ static void brisk_dash_window_associate_category(BriskMenuWindow *self, GtkWidge
                                  "enter-notify-event",
                                  G_CALLBACK(brisk_dash_window_on_enter),
                                  self);
+        g_signal_connect_swapped(button,
+                                 "focus-in-event",
+                                 G_CALLBACK(brisk_dash_window_on_enter),
+                                 self);
 }
 
 /**
@@ -506,10 +512,9 @@ static void brisk_dash_window_on_toggled(BriskMenuWindow *self, GtkWidget *butto
 }
 
 /**
- * Fired by entering into the category button with a roll over
+ * Fired by entering into the category button
  */
-static gboolean brisk_dash_window_on_enter(BriskMenuWindow *self,
-                                           __brisk_unused__ GdkEventCrossing *event,
+static gboolean brisk_dash_window_on_enter(BriskMenuWindow *self, __brisk_unused__ GdkEvent *event,
                                            GtkWidget *button)
 {
         GtkToggleButton *but = GTK_TOGGLE_BUTTON(button);
@@ -523,7 +528,8 @@ static gboolean brisk_dash_window_on_enter(BriskMenuWindow *self,
                 return GDK_EVENT_PROPAGATE;
         }
 
-        /* Force activation through rollover */
+        /* Force activation */
+        gtk_widget_grab_focus(button);
         gtk_toggle_button_set_active(but, TRUE);
 
         return GDK_EVENT_PROPAGATE;


### PR DESCRIPTION
Instead of disabling focus, we reuse the rollover functionality to
enable listening for focus events, then we activate the corresponding
category.

Fixes https://github.com/getsolus/brisk-menu/issues/8