### PR TITLE
Attempt to fix build order bug

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -13,6 +13,7 @@ libresources = static_library(
 
 link_libresources = declare_dependency(
     link_with: libresources,
+    sources: brisk_resources,
     include_directories: [
         data_include,
     ],
@@ -38,6 +39,7 @@ libsession_stub = static_library(
 # Allow linking to the stub
 link_libsession_stub = declare_dependency(
     link_with: libsession_stub,
+    sources: [libsaver_glue, libsession_glue],
     dependencies: [
         dep_gio_unix,
     ],


### PR DESCRIPTION
Uncovered while building with samurai [0] but can probably also
happen with ninja eventually.

In file included from ../src/mate-applet/applet.c:19:
In file included from ../src/frontend/classic/classic-window.h:14:
../src/frontend/classic/../menu-private.h:18:10: fatal error: 'libsaver-glue.h' file not found
 #include "libsaver-glue.h"
         ^~~~~~~~~~~~~~~~~
1 error generated.
samu: subcommands failed

I'm not sure if this is right at all, but it fixed the build for me.

[0] https://github.com/michaelforney/samurai