### PR TITLE
Fixed sorting entries with accented first letters

### DIFF
--- a/src/frontend/menu-sort.c
+++ b/src/frontend/menu-sort.c
@@ -74,10 +74,10 @@ __brisk_pure__ gint brisk_menu_window_sort(BriskMenuWindow *self, BriskItem *ite
 
 basic_sort:
         /* Ensure we compare lower case only */
-        nameA = g_ascii_strdown(brisk_item_get_display_name(itemA), -1);
-        nameB = g_ascii_strdown(brisk_item_get_display_name(itemB), -1);
+        nameA = g_utf8_strdown(brisk_item_get_display_name(itemA), -1);
+        nameB = g_utf8_strdown(brisk_item_get_display_name(itemB), -1);
 
-        return g_strcmp0(nameA, nameB);
+        return g_strcmp0(g_utf8_collate_key(nameA, -1), g_utf8_collate_key(nameB, -1));
 }
 
 /*


### PR DESCRIPTION
In some rare cases, menu entries will have an accented uppercase first letter.
g_ascii_strdown doesn't work on such letters.
g_utf8_strdown will change the letter to the lowercase equivalent, i.e. À becomes à.

g_strcmp0 doesn't sort using linguistically correct rules for the current locale, i.e. it will place é after z.

g_utf8_collate properly compares two strings, using the linguistically correct rules for the current locale, i.e. it will consider "é" as an equivalent of "e", and properly place "Économiseur d'écran" before "Evolution".

However, the documentation for g_utf8_collate says that, "when sorting a large number of strings, it will be significantly faster to obtain collation keys with g_utf8_collate_key() and compare the keys with strcmp()", so that's what I used here.

I have tested this PR on Ubuntu MATE 21.04, with MATE 1.26.0 installed from the fresh-mate PPA.
